### PR TITLE
Make deconstructor virtual

### DIFF
--- a/src/RCOMObject.h
+++ b/src/RCOMObject.h
@@ -98,7 +98,7 @@ class RCOMObject : public IDispatch
                           if(def != R_NilValue)
                              setObject(def);
                        };
-  ~RCOMObject() {
+  virtual ~RCOMObject() {
                   m_cRef--;
                   if(m_cRef == 0) {
 		    destroy();


### PR DESCRIPTION
Fixes a GCC warning and linking error from gcc v4.9.3

RCOMObject.h: In member function 'virtual ULONG RCOMObject::Release()':
RCOMObject.h:72:50: warning: deleting object of abstract class type 'RCOMObject' which has non-virtual destructor will cause undefined behaviour [-Wdelete-non-virtual-dtor]
                                           delete this;

Windows R will be migrating to the 4.9.3 toolchain with the upcoming release on May 3rd, so this fix should be sent to CRAN very soon.