### PR TITLE
Fix build with LLVM/clang.

### DIFF
--- a/src/COMError.cpp
+++ b/src/COMError.cpp
@@ -58,9 +58,9 @@
 /* Parentheses added for FC4 with gcc4 and -D_FORTIFY_SOURCE=2 */
 #define PROBLEM			{char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
 #define MESSAGE                 {char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
-#define ERROR			),Rf_error(R_problem_buf);}
-#define RECOVER(x)		),Rf_error(R_problem_buf);}
-#define WARNING(x)		),Rf_warning(R_problem_buf);}
+#define ERROR			),Rf_error("%s", R_problem_buf);}
+#define RECOVER(x)		),Rf_error("%s", R_problem_buf);}
+#define WARNING(x)		),Rf_warning("%s", R_problem_buf);}
 #define LOCAL_EVALUATOR		/**/
 #define NULL_ENTRY		/**/
 #define WARN			WARNING(NULL)

--- a/src/RCOMObject.h
+++ b/src/RCOMObject.h
@@ -43,13 +43,9 @@
 
 #undef ERROR
 
-extern "C" {
 #include <Rinternals.h>
-  //#include <Defn.h>
+//#include <Defn.h>
 #include <Rdefines.h>
-  extern void R_PreserveObject(SEXP);
-  extern void R_ReleaseObject(SEXP);
-}
 
 #ifdef length
 #undef length

--- a/src/RUtils.c
+++ b/src/RUtils.c
@@ -53,9 +53,9 @@
 /* Parentheses added for FC4 with gcc4 and -D_FORTIFY_SOURCE=2 */
 #define PROBLEM			{char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
 #define MESSAGE                 {char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
-#define ERROR			),Rf_error(R_problem_buf);}
-#define RECOVER(x)		),Rf_error(R_problem_buf);}
-#define WARNING(x)		),Rf_warning(R_problem_buf);}
+#define ERROR			),Rf_error("%s", R_problem_buf);}
+#define RECOVER(x)		),Rf_error("%s", R_problem_buf);}
+#define WARNING(x)		),Rf_warning("%s", R_problem_buf);}
 #define LOCAL_EVALUATOR		/**/
 #define NULL_ENTRY		/**/
 #define WARN			WARNING(NULL)

--- a/src/connect.cpp
+++ b/src/connect.cpp
@@ -30,11 +30,9 @@
 #endif
 
 
-extern "C" {
 #include "RUtils.h"
 #include <Rinternals.h>
 #include <Rdefines.h>
-}
 
 #include <R_ext/Error.h>	/* for Rf_error and Rf_warning */
 
@@ -77,9 +75,9 @@ extern "C" {
 /* Parentheses added for FC4 with gcc4 and -D_FORTIFY_SOURCE=2 */
 #define PROBLEM			{char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
 #define MESSAGE                 {char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
-#define ERROR			),Rf_error(R_problem_buf);}
-#define RECOVER(x)		),Rf_error(R_problem_buf);}
-#define WARNING(x)		),Rf_warning(R_problem_buf);}
+#define ERROR			),Rf_error("%s", R_problem_buf);}
+#define RECOVER(x)		),Rf_error("%s", R_problem_buf);}
+#define WARNING(x)		),Rf_warning("%s", R_problem_buf);}
 #define LOCAL_EVALUATOR		/**/
 #define NULL_ENTRY		/**/
 #define WARN			WARNING(NULL)

--- a/src/converters.cpp
+++ b/src/converters.cpp
@@ -67,9 +67,9 @@ extern "C" {
 /* Parentheses added for FC4 with gcc4 and -D_FORTIFY_SOURCE=2 */
 #define PROBLEM			{char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
 #define MESSAGE                 {char R_problem_buf[R_PROBLEM_BUFSIZE];(snprintf)(R_problem_buf, R_PROBLEM_BUFSIZE,
-#define ERROR			),Rf_error(R_problem_buf);}
-#define RECOVER(x)		),Rf_error(R_problem_buf);}
-#define WARNING(x)		),Rf_warning(R_problem_buf);}
+#define ERROR			),Rf_error("%s", R_problem_buf);}
+#define RECOVER(x)		),Rf_error("%s", R_problem_buf);}
+#define WARNING(x)		),Rf_warning("%s", R_problem_buf);}
 #define LOCAL_EVALUATOR		/**/
 #define NULL_ENTRY		/**/
 #define WARN			WARNING(NULL)


### PR DESCRIPTION
When using C++ compiler, R headers cannot be included from "extern C" blocks, because they include some C++ headers (which may e.g. have templates, which cannot be with a C linkage). R headers, after including C++ headers, would themselves use "extern C" when needed. This problem prevents the package from building with LLVM 17 clang.

I've also fixed the error and warning calls to always pass a format string, to avoid warnings.